### PR TITLE
Add read status tracking for reflections

### DIFF
--- a/backend/src/models/SelfReflection.ts
+++ b/backend/src/models/SelfReflection.ts
@@ -6,6 +6,7 @@ export interface ISelfReflection extends Document {
   description: string;
   date: Date;
   type: 'pipo' | 'self';
+  readAt: Date | null;
   imageName?: string; // For Pipo avatar image
   linkedSessionId?: mongoose.Types.ObjectId; // Link to PracticeSession
   scenarioId?: mongoose.Types.ObjectId; // Quick reference to scenario
@@ -43,6 +44,11 @@ const SelfReflectionSchema = new Schema<ISelfReflection>(
       required: true,
       default: 'self',
     },
+    readAt: {
+      type: Date,
+      default: null,
+      // Null until the user views the note
+    },
     imageName: {
       type: String,
       trim: true,
@@ -78,6 +84,7 @@ SelfReflectionSchema.index({ userId: 1, date: -1 });
 SelfReflectionSchema.index({ userId: 1, type: 1, date: -1 });
 SelfReflectionSchema.index({ linkedSessionId: 1 });
 SelfReflectionSchema.index({ userId: 1, scenarioId: 1, level: 1 });
+SelfReflectionSchema.index({ userId: 1, type: 1, readAt: 1 });
 
 const SelfReflection = mongoose.model<ISelfReflection>(
   'SelfReflection',
@@ -85,4 +92,3 @@ const SelfReflection = mongoose.model<ISelfReflection>(
 );
 
 export default SelfReflection;
-

--- a/backend/src/routes/routes.ts
+++ b/backend/src/routes/routes.ts
@@ -231,6 +231,13 @@ router.get('/reflections/:reflectionId', verifyFirebaseToken, controllers.getRef
 // PUT /api/reflections/:reflectionId - Update reflection
 router.put('/reflections/:reflectionId', verifyFirebaseToken, controllers.updateReflection);
 
+// PATCH /api/reflections/:reflectionId/read-status - Update reflection read status
+router.patch(
+  '/reflections/:reflectionId/read-status',
+  verifyFirebaseToken,
+  controllers.updateReflectionReadStatus
+);
+
 // DELETE /api/reflections/:reflectionId - Delete reflection
 router.delete('/reflections/:reflectionId', verifyFirebaseToken, controllers.deleteReflection);
 

--- a/backend/src/routes/selfReflection.routes.ts
+++ b/backend/src/routes/selfReflection.routes.ts
@@ -6,6 +6,7 @@ import {
   updateReflection,
   deleteReflection,
   getReflectionDates,
+  updateReflectionReadStatus,
 } from '../controllers/selfReflection.controller';
 
 const router = Router();
@@ -25,8 +26,10 @@ router.get('/:reflectionId', getReflectionById);
 // Update a reflection
 router.put('/:reflectionId', updateReflection);
 
+// Update read status for a reflection
+router.patch('/:reflectionId/read-status', updateReflectionReadStatus);
+
 // Delete a reflection
 router.delete('/:reflectionId', deleteReflection);
 
 export default router;
-

--- a/src/Components/Notebook/PipoDetailScreen.js
+++ b/src/Components/Notebook/PipoDetailScreen.js
@@ -1,7 +1,7 @@
-import React, { useLayoutEffect, useState } from "react";
+import React, { useEffect, useLayoutEffect, useState } from "react";
 import { SafeAreaView, View, Text, StyleSheet, Pressable, ScrollView, Image, Alert } from "react-native";
 import MaterialIcons from "react-native-vector-icons/MaterialIcons";
-import { deleteReflection } from "../../services/api";
+import { deleteReflection,updateReflectionReadStatus } from "../../services/api";
 
 export default function PipoDetailScreen({ route, navigation }) {
   const { pipo } = route.params || {};
@@ -52,6 +52,39 @@ export default function PipoDetailScreen({ route, navigation }) {
         ),
     });
   }, [navigation, deleting, isDeleted]);
+
+ 
+
+  useEffect(() => {
+    if (!pipo?.id) return;
+    if (pipo?.readAt != null) return; 
+
+    let stop = false;
+    (async () => {
+      try {
+        await updateReflectionReadStatus(pipo?.id, { readAt: new Date().toISOString() });
+      } catch (e) {
+        if (!stop) console.error("Failed to set readAt:", e);
+      }
+    })();
+
+    return () => { stop = true; };
+  }, [pipo?.id, pipo?.readAt]);
+
+//   useEffect(() => {
+//   const reflectionId = pipo?._id || pipo?.id;
+//   if (!reflectionId) return;
+
+//   (async () => {
+//     try {
+//       // for testing
+//       await updateReflectionReadStatus(reflectionId, { readAt: null });
+//       console.log('readAt set to null for testing');
+//     } catch (e) {
+//       console.error('Failed to set readAt null:', e);
+//     }
+//   })();
+// }, [pipo?._id, pipo?.id]);
 
   if (!pipo) {
     return (

--- a/src/screens/NotebookScreen.js
+++ b/src/screens/NotebookScreen.js
@@ -606,6 +606,7 @@ export default function NotebookScreen({ navigation }) {
                           subtitle: item.subtitle,
                           dateISO: selectedDate,
                           dateText: dayjs(selectedDate).format("ddd, MMM D").toUpperCase(),
+                          readAt: item.readAt,
                           sessionId: item.sessionId,
                           scenarioId: item.scenarioId,
                           level: item.level,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -393,6 +393,7 @@ export type Reflection = {
   description: string;
   date: string;
   type: 'pipo' | 'self';
+  readAt: string | null;
   imageName?: string; // For Pipo avatar image
   linkedSessionId?: string; // Link to PracticeSession
   scenarioId?: string; // Reference to scenario
@@ -408,6 +409,7 @@ export type CreateReflectionData = {
   date: string;
   type?: 'pipo' | 'self';
   imageName?: string; // For Pipo avatar image
+  readAt?: string | null;
 };
 
 export type UpdateReflectionData = {
@@ -416,6 +418,7 @@ export type UpdateReflectionData = {
   date?: string;
   type?: 'pipo' | 'self';
   imageName?: string; // For Pipo avatar image
+  readAt?: string | null;
 };
 
 /**
@@ -552,6 +555,35 @@ export const updateReflection = async (
   } catch (error: any) {
     console.error(
       '❌ Failed to update reflection:',
+      error.response?.data || error.message,
+    );
+    throw error;
+  }
+};
+
+/**
+ * Update the read status of a reflection
+ */
+export const updateReflectionReadStatus = async (
+  reflectionId: string,
+  payload:
+    | { read: boolean }
+    | { readAt: string | null },
+): Promise<Reflection> => {
+  try {
+    const response = await apiClient.patch<ApiSuccessEnvelope<Reflection>>(
+      `/reflections/${reflectionId}/read-status`,
+      payload,
+    );
+
+    if (!response.data?.success || !response.data?.data) {
+      throw new Error('Failed to update reflection read status');
+    }
+
+    return response.data.data;
+  } catch (error: any) {
+    console.error(
+      '❌ Failed to update reflection read status:',
       error.response?.data || error.message,
     );
     throw error;


### PR DESCRIPTION
Introduces a `readAt` field to the SelfReflection model and API, allowing tracking of when a reflection is read. Adds backend endpoints and logic to update read status, and updates frontend to mark reflections as read and display unread indicators.