### PR TITLE
Add reusable ConfirmDialog and integrate in screens

### DIFF
--- a/src/Components/AlertBox/ConfirmDialog.js
+++ b/src/Components/AlertBox/ConfirmDialog.js
@@ -1,0 +1,208 @@
+import React, { useEffect, useRef } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  Pressable,
+  StyleSheet,
+  Animated,
+  Platform,
+} from "react-native";
+
+const ConfirmDialog = ({
+  visible, // visibility controll of modal
+  title = "Are you sure?",
+  message = "This action cannot be undone.",
+  secondaryMessage = "All related data will be permanently removed.",
+  confirmText = "DELETE",
+  cancelText = "CANCEL",
+  onConfirm, //func that will run
+  onCancel,
+  loading = false,
+  blockDismiss = false,
+  primaryColor = "rgba(62, 49, 83, 1)",
+  backdropOpacity = 0.55, //Opacity of the background overlay
+  testID = "confirm-dialog",
+}) => {
+  const fade = useRef(new Animated.Value(0)).current;
+  const scale = useRef(new Animated.Value(0.98)).current;
+
+  useEffect(() => {
+    if (visible) {
+      Animated.parallel([
+        Animated.timing(fade, { toValue: backdropOpacity, duration: 180, useNativeDriver: true }),
+        Animated.spring(scale, { toValue: 1, useNativeDriver: true, damping: 15, stiffness: 120 }),
+      ]).start();
+    } else {
+      Animated.parallel([
+        Animated.timing(fade, { toValue: 0, duration: 140, useNativeDriver: true }),
+        Animated.timing(scale, { toValue: 0.98, duration: 140, useNativeDriver: true }),
+      ]).start();
+    }
+  }, [visible, backdropOpacity, fade, scale]);
+
+  const requestClose = () => {
+    if (!blockDismiss && !loading) onCancel && onCancel();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none"
+      onRequestClose={requestClose}
+      statusBarTranslucent
+    >
+      {/* Backdrop */}
+      <Animated.View style={[styles.backdrop, { opacity: fade }]}>
+        <Pressable style={styles.fill} onPress={requestClose} />
+      </Animated.View>
+
+      {/* Card */}
+      <View style={styles.centerWrap} pointerEvents="box-none">
+        <Animated.View style={[styles.card, { transform: [{ scale }] }]}>
+          {!!title && <Text style={styles.title}>{title}</Text>}
+          {!!message && <Text style={styles.message}>{message}</Text>}
+          {!!secondaryMessage && (
+            <Text style={[styles.message, styles.secondary]}>{secondaryMessage}</Text>
+          )}
+
+          <View style={styles.row}>
+           
+            <Pressable
+              accessibilityRole="button"
+              testID={`${testID}-confirm`}
+              disabled={loading}
+              onPress={onConfirm}
+              style={({ pressed }) => [
+                styles.button,
+                styles.buttonOutlined,
+                { borderColor: primaryColor, opacity: loading ? 0.6 : pressed ? 0.9 : 1 },
+              ]}
+            >
+              <Text style={[styles.buttonText, { color: primaryColor }]}>{confirmText}</Text>
+            </Pressable>
+
+        
+            <Pressable
+              accessibilityRole="button"
+              testID={`${testID}-cancel`}
+              disabled={loading}
+              onPress={onCancel}
+              style={({ pressed }) => [
+                styles.button,
+                styles.buttonFilled,
+                { backgroundColor: primaryColor, opacity: loading ? 0.6 : pressed ? 0.9 : 1 },
+              ]}
+            >
+              <Text style={[styles.buttonText, styles.buttonTextFilled]}>{cancelText}</Text>
+            </Pressable>
+          </View>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "#000",
+  },
+  fill: { flex: 1 },
+  centerWrap: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 16,
+  },
+  card: {
+    width: "90%",
+    maxWidth: 520,
+    borderRadius: 20,
+    backgroundColor: "#fff",
+    paddingVertical: 20,
+    paddingHorizontal: 20,
+    shadowColor: "#000",
+    shadowOpacity: 0.12,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 5 },
+    elevation: 4,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: "#111",
+    marginBottom: 12,
+    textAlign: "left",
+  },
+  message: {
+    fontSize: 15,
+    color: "#333",
+    lineHeight: 22,
+    textAlign: "left",
+  },
+  secondary: {
+    fontSize: 15,
+    color: "#333",
+    textAlign: "left",
+    marginTop: 4,
+  },
+  row: {
+    marginTop: 20,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    gap: 12,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 24,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  buttonOutlined: {
+    borderWidth: 2,
+    backgroundColor: "#fff",
+  },
+  buttonFilled: {
+    borderWidth: 0,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: "700",
+    letterSpacing: 1,
+  },
+  buttonTextFilled: {
+    color: "#fff",
+  },
+});
+
+
+export default ConfirmDialog;
+
+{/* import ConfirmDialog from "../components/ConfirmDialog";
+ *
+ * export default function ExampleScreen() {
+ *   const [open, setOpen] = useState(false);
+ *
+ *   return (
+ *     <View style={{ flex: 1, justifyContent: "center", alignItems: "center" }}>
+ *       <Button title="Show Dialog" onPress={() => setOpen(true)} />
+ *
+ *       <ConfirmDialog
+ *         visible={open}
+ *         title="Delete Note?"
+ *         message="This action cannot be undone."
+ *         secondaryMessage="Your note and all data will be deleted permanently."
+ *         confirmText="DELETE"
+ *         cancelText="CANCEL"
+ *         onConfirm={() => {
+ *           // Handle delete logic here
+ *           setOpen(false);
+ *         }}
+ *         onCancel={() => setOpen(false)}
+ *       />
+ *     </View>
+ *   );
+ */ }

--- a/src/Components/Notebook/PipoDetailScreen.js
+++ b/src/Components/Notebook/PipoDetailScreen.js
@@ -2,40 +2,59 @@ import React, { useEffect, useLayoutEffect, useState } from "react";
 import { SafeAreaView, View, Text, StyleSheet, Pressable, ScrollView, Image, Alert } from "react-native";
 import MaterialIcons from "react-native-vector-icons/MaterialIcons";
 import { deleteReflection,updateReflectionReadStatus } from "../../services/api";
+import ConfirmDialog from '../AlertBox/ConfirmDialog'
 
 export default function PipoDetailScreen({ route, navigation }) {
   const { pipo } = route.params || {};
   const [deleting, setDeleting] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
 
   const handleDelete = () => {
     if (!pipo?.id || deleting || isDeleted) return;
-
-    Alert.alert(
-      "Delete note?",
-      "This will permanently remove this Pipo note.",
-      [
-        { text: "Cancel", style: "cancel" },
-        {
-          text: "Delete",
-          style: "destructive",
-          onPress: async () => {
-            setDeleting(true);
-            try {
-              await deleteReflection(pipo.id);
-              setIsDeleted(true);
-            } catch (e) {
-              console.error("Delete failed:", e);
-              Alert.alert("Error", "Could not delete. Please try again.");
-            } finally {
-              setDeleting(false);
-            }
-          },
-        },
-      ],
-      { cancelable: true }
-    );
+    setShowConfirm(true);
+    // Alert.alert(
+    //   "Delete note?",
+    //   "This will permanently remove this Pipo note.",
+    //   [
+    //     { text: "Cancel", style: "cancel" },
+    //     {
+    //       text: "Delete",
+    //       style: "destructive",
+    //       onPress: async () => {
+    //         setDeleting(true);
+    //         try {
+    //           await deleteReflection(pipo.id);
+    //           setIsDeleted(true);
+    //         } catch (e) {
+    //           console.error("Delete failed:", e);
+    //           Alert.alert("Error", "Could not delete. Please try again.");
+    //         } finally {
+    //           setDeleting(false);
+    //         }
+    //       },
+    //     },
+    //   ],
+    //   { cancelable: true }
+    // );
   };
+
+  const confirmDelete = async () => {
+  if (!pipo?.id) return;
+  setDeleting(true);
+  try {
+    await deleteReflection(pipo.id);
+    setIsDeleted(true);
+    setShowConfirm(false);
+  } catch (e) {
+    console.error("Delete failed:", e);
+    Alert.alert("Error", "Could not delete. Please try again.");
+  } finally {
+    setDeleting(false);
+  }
+};
+
 
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -146,6 +165,18 @@ export default function PipoDetailScreen({ route, navigation }) {
           </>
         )}
       </ScrollView>
+      <ConfirmDialog
+  visible={showConfirm}
+  title="Are you sure?"
+  message="This action cannot be undone."
+  secondaryMessage="All related data will be permanently removed."
+  confirmText="DELETE"
+  cancelText="CANCEL"
+  onConfirm={confirmDelete}
+  onCancel={() => setShowConfirm(false)}
+  loading={deleting}
+/>
+
     </SafeAreaView>
   );
 }

--- a/src/pages/ProfileSettingScreen.js
+++ b/src/pages/ProfileSettingScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"; 
+import React, { useState, useEffect } from "react";
 import {
   View,
   Text,
@@ -16,6 +16,7 @@ import { useAuth } from "../contexts/AuthContext";
 import { updateUserProfile } from "../services/api";
 import { updatePassword, EmailAuthProvider, reauthenticateWithCredential } from "firebase/auth";
 import { auth } from "../firebase";
+import ConfirmDialog from '../Components/AlertBox/ConfirmDialog'
 
 export default function ProfileSettingScreen({ navigation }) {
   const { user, mongoUser, refreshMongoUser } = useAuth();
@@ -27,12 +28,13 @@ export default function ProfileSettingScreen({ navigation }) {
   const [selectedAvatar, setSelectedAvatar] = useState(0);
   const [loading, setLoading] = useState(false);
   const [initialLoading, setInitialLoading] = useState(true);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   const avatars = [
     { name: "pipo_set", image: require("../../assets/pipo_set.png") },
     { name: "bro_set", image: require("../../assets/bro_set.png") },
     { name: "cherry_set", image: require("../../assets/cherry_set.png") },
-    { name: "mshrom_set", image: require("../../assets/mshrom_set.png")}
+    { name: "mshrom_set", image: require("../../assets/mshrom_set.png") }
   ];
 
   // Load user data when component mounts
@@ -85,7 +87,7 @@ export default function ProfileSettingScreen({ navigation }) {
 
       //     // Update password
       //     await updatePassword(user, newPassword);
-          
+
       //     Alert.alert(
       //       "Success",
       //       "Profile and password updated successfully!",
@@ -117,7 +119,7 @@ export default function ProfileSettingScreen({ navigation }) {
 
       // Refresh MongoDB user data
       await refreshMongoUser();
-      
+
       setLoading(false);
       navigation.navigate("Home");
     } catch (error) {
@@ -139,7 +141,7 @@ export default function ProfileSettingScreen({ navigation }) {
 
   return (
     <SafeAreaView style={styles.container}>
-      <ScrollView 
+      <ScrollView
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
@@ -229,11 +231,11 @@ export default function ProfileSettingScreen({ navigation }) {
           </View>
         </View> */}
 
-        
+
 
         {/* Save Button */}
-        <TouchableOpacity 
-          onPress={handleSave} 
+        <TouchableOpacity
+          onPress={() => setShowConfirm(true)}
           style={[styles.saveButton, loading && styles.saveButtonDisabled]}
           disabled={loading}
         >
@@ -246,13 +248,30 @@ export default function ProfileSettingScreen({ navigation }) {
 
         <View style={{ height: 20 }} />
       </ScrollView>
+      <ConfirmDialog
+        visible={showConfirm}
+        title="Save changes?"
+        message="This will update your profile details."
+        secondaryMessage="You can edit them again anytime."
+        confirmText="SAVE"
+        cancelText="CANCEL"
+        loading={loading}
+        blockDismiss={loading}
+        primaryColor="rgba(62, 49, 83, 1)"
+        onCancel={() => setShowConfirm(false)}
+        onConfirm={async () => {
+          await handleSave();
+          setShowConfirm(false);
+        }}
+      />
+
     </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: "#EAF1FF" },
-  scrollContent: { 
+  scrollContent: {
     alignItems: "center",
     paddingBottom: 20,
   },


### PR DESCRIPTION
Introduced a reusable ConfirmDialog component for confirmation modals. Replaced Alert-based delete/save confirmations in PipoDetailScreen, ProfileSettingScreen, and NotebookScreen with ConfirmDialog for improved UI consistency and better control over modal behavior.