### PR TITLE
Fix line break in onboarding question text

### DIFF
--- a/src/pages/Onboarding.js
+++ b/src/pages/Onboarding.js
@@ -19,7 +19,7 @@ import { CommonActions, useNavigation } from '@react-navigation/native';
 const questionList = [
   'I avoid certain social situations because I’m afraid of embarrassing myself.',
   'My heart races or I overthink before speaking in front of others.',
-  'I criticize myself harshly after social interactions.',
+  'I criticize myself harshly after \nsocial interactions.',
   'I find it hard to relax or fall asleep after a party or social event.',
   'I worry for a long time, replaying what I said or did.',
 ];


### PR DESCRIPTION
Added a line break in the third onboarding question to improve text formatting and readability.