### PR TITLE
Improve reflection fetch logic and AI question count

### DIFF
--- a/backend/src/services/practiceSessionAIService.ts
+++ b/backend/src/services/practiceSessionAIService.ts
@@ -255,7 +255,8 @@ export const prepareSessionDataForAI = (session: any, scenarioTitle?: string): S
   };
 };
 
-// Generate 3–4 next-level questions based on scenario and level (independent questions, not dependent on previous answers)
+// Generate next-level questions based on scenario and level (independent questions, not dependent on previous answers)
+// Level 2: exactly 3 questions, Level 3: exactly 2 questions
 export const generateNextLevelQuestions = async (
   sessionData: SessionDataForAI & { nextLevel: 2 | 3; scenarioTitle?: string }
 ) => {
@@ -269,10 +270,11 @@ export const generateNextLevelQuestions = async (
   const scenarioTitle = sessionData.scenarioTitle || 'Practice';
   const level = sessionData.level;
   const nextLevel = sessionData.nextLevel;
+  const questionCount = nextLevel === 2 ? 3 : 2;
 
   const system = 'You design short role-play prompts. Output only valid JSON as specified.';
   const userPrompt = `
-Create ${nextLevel === 2 ? '3-4' : '3-4'} next-step questions for a user practicing "${scenarioTitle}".
+Create exactly ${questionCount} next-step questions for a user practicing "${scenarioTitle}".
 
 Context:
 - Current Level: ${level}
@@ -324,8 +326,15 @@ Return JSON only:
     const parsed = JSON.parse(match[0]);
     const questions = Array.isArray(parsed.questions) ? parsed.questions : [];
 
-    console.log('🧪 Next-level questions preview:', questions.slice(0, 2));
-    return questions;
+    // Ensure we return exactly the requested number of questions
+    const trimmedQuestions = questions.slice(0, questionCount);
+    
+    if (trimmedQuestions.length !== questionCount) {
+      console.warn(`⚠️ Expected ${questionCount} questions but got ${questions.length}. Returning ${trimmedQuestions.length}.`);
+    }
+
+    console.log('🧪 Next-level questions preview:', trimmedQuestions.slice(0, 2));
+    return trimmedQuestions;
   } catch (error: any) {
     console.error('❌ OpenAI error generating next questions:', error.response?.data || error.message);
     return [];

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
+    "start:reset": "react-native start --reset-cache",
     "test": "jest"
   },
   "dependencies": {

--- a/src/navigation/MainStack.js
+++ b/src/navigation/MainStack.js
@@ -40,7 +40,7 @@ import Level3IntroScreen from '../pages/level3/Level3IntroScreen';
 import Level3Screen from '../pages/level3/Level3Screen';
 import Level3ResultScreen from '../pages/level3/Level3ResultScreen';
 
-import SpecialMissionScreen from '../pages/levels/SpecialMissionScreen';
+import SpecialMissionScreen from '../pages/Levels/SpecialMissionScreen';
 
 import SignupScreen from '../screens/auth/SignupScreen.js';
 import LoginScreen from '../screens/auth/LoginScreen.js';


### PR DESCRIPTION
Refines backend AI question generation to return exactly 3 questions for level 2 and 2 for level 3, trimming excess if needed. Enhances NotebookScreen state management to avoid redundant fetches, adds tracking for last fetched date/tab, and improves tab/date change handling for more efficient and reliable data updates. Also fixes import path casing in MainStack and adds a start:reset script to package.json.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces exact next-level AI question counts (L2=3, L3=2) and streamlines NotebookScreen data fetching with caching/abort logic; also fixes a navigation import path and adds a start:reset script.
> 
> - **Backend**:
>   - **`backend/src/services/practiceSessionAIService.ts`**: `generateNextLevelQuestions` now returns exactly 3 questions for level 2 and 2 for level 3; prompt updated and results trimmed; logging tweaked.
> - **App (Notebook)**:
>   - **`src/screens/NotebookScreen.js`**:
>     - Adds fetch deduping via `lastFetchedDateRef`, `lastFetchedTabRef`, `hasInitialFetchedRef`, and `isFocusFetchingRef`.
>     - Improves effects to skip redundant fetches; resets tracking on tab/date changes.
>     - Strengthens abort handling with `AbortController` for cards/dots; better error handling.
>     - Refresh now forces fresh fetches; minor refactors and logging cleanups.
> - **Navigation**:
>   - **`src/navigation/MainStack.js`**: Fix import path casing for `SpecialMissionScreen`.
> - **Scripts**:
>   - **`package.json`**: Add `start:reset` script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01ad9c56ef29ead49428630c3061a53a641cda48. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->